### PR TITLE
Updated webrtc and add bootstrap option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ const hyperswarm = require('hyperswarm-web')
 const crypto = require('crypto')
 
 const swarm = hyperswarm({
-  // If you omit this, it'll try to connect to 'wss://hyperswarm.mauve.moe'
-  // It will also attempt to connect to a local proxy on `ws://localhost:4977`
-  wsProxy: 'ws://yourproxy.com',
+  // Specify a server list of HyperswarmServer instances
+  bootstrap: ['ws://yourhyperswarmserver.com'],
   // The configuration passed to the SimplePeer constructor
   //See https://github.com/feross/simple-peer#peer--new-peeropts
   // for more options

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ const crypto = require('crypto')
 const swarm = hyperswarm({
   // Specify a server list of HyperswarmServer instances
   bootstrap: ['ws://yourhyperswarmserver.com'],
+  // You can also specify proxy and signal servers separated
+  wsProxy: [
+    'ws://proxy1.com',
+    'ws://proxy2.com'
+  ],
+  webrtcBootstrap: [
+    'ws://signal1.com',
+    'ws://signal2.com'
+  ],
   // The configuration passed to the SimplePeer constructor
   //See https://github.com/feross/simple-peer#peer--new-peeropts
   // for more options
@@ -51,6 +60,13 @@ Build it with [Browserify](http://browserify.org/) to get it running on the web.
 You could also compile an existing codebase relying on hyperswarm to run on the web by adding a `browser` field set to `{"hyperswarm": "hyperswarm-web"}` to have Browserify alias it when compiling dependencies.
 
 ## Setting up a proxy server
+
+`HyperswarmServer` provides two services:
+
+  - [HyperswarmProxyWS](https://github.com/RangerMauve/hyperswarm-proxy-ws): to proxy hyperswarm connections over websockets. Path: `ws://yourserver/proxy`
+  - [SignalServer](https://github.com/geut/discovery-swarm-webrtc#server): for P2P WebRTC signaling connections. Path: `ws://yourserver/signal`
+
+Running a `HyperswarmServer` will allows you to use both services in one single process.
 
 ```
 npm i -g hyperswarm-web

--- a/bin.js
+++ b/bin.js
@@ -24,5 +24,7 @@ wsServer.listenOnServer(server)
 const port = argv.port ? parseInt(argv.port, 10) : DEFAULT_PORT
 
 console.log(`Listening on ws://localhost:${port}`)
+console.log(`-> Proxy available on ws://localhost:${port}/proxy`)
+console.log(`-> Signal available on ws://localhost:${port}/signal`)
 
 server.listen(port)

--- a/bin.js
+++ b/bin.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-const HyperswarmServer = require('hyperswarm-proxy-ws/server')
+const HyperswarmServer = require('./server')
+
 const http = require('http')
 const send = require('send')
 const path = require('path')

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@geut/discovery-swarm-webrtc": "^4.0.0",
     "duplexpair": "^1.0.1",
-    "hyperswarm-proxy-ws": "github:tinchoz49/hyperswarm-proxy-ws#tinchoz49/multiple-proxies",
+    "hyperswarm-proxy-ws": "^1.1.0",
     "minimist": "^1.2.0",
     "send": "^0.17.1",
     "websocket-stream": "^5.5.2"

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
   },
   "homepage": "https://github.com/RangerMauve/hyperswarm-web#readme",
   "dependencies": {
-    "@geut/discovery-swarm-webrtc": "^2.2.4",
+    "@geut/discovery-swarm-webrtc": "^4.0.0",
     "duplexpair": "^1.0.1",
-    "hyperswarm-proxy-ws": "^1.0.0",
+    "hyperswarm-proxy-ws": "github:tinchoz49/hyperswarm-proxy-ws#tinchoz49/multiple-proxies",
     "minimist": "^1.2.0",
-    "send": "^0.17.1"
+    "send": "^0.17.1",
+    "websocket-stream": "^5.5.2"
   },
   "devDependencies": {
     "get-port": "^5.1.0",

--- a/server.js
+++ b/server.js
@@ -19,14 +19,13 @@ class HyperswarmServer extends HyperswarmProxyWSServer {
     server.on('upgrade', function upgrade(request, socket, head) {
       const pathname = url.parse(request.url).pathname;
 
-      if (pathname === '/proxy') {
-        proxyWss.handleUpgrade(request, socket, head, (ws) => proxyWss.emit('connection', ws, request));
-      } else if (pathname === '/signal') {
+      if (pathname === '/signal') {
         signalWss.handleUpgrade(request, socket, head, (ws) => signalWss.emit('connection', ws, request));
-      } else {
-        console.warn('Invalid path. The path must be "/proxy" or "/signal"')
-        socket.destroy();
+        return
       }
+
+      // proxy
+      proxyWss.handleUpgrade(request, socket, head, (ws) => proxyWss.emit('connection', ws, request));
     });
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,34 @@
+
+const HyperswarmProxyWSServer = require('hyperswarm-proxy-ws/server')
+const { SignalServer } = require('@geut/discovery-swarm-webrtc/server')
+const websocket = require('websocket-stream')
+
+const url = require('url')
+
+class HyperswarmServer extends HyperswarmProxyWSServer {
+  listenOnServer (server) {
+    this.server = server
+
+    const proxyWss = this.websocketServer = websocket.createServer({ noServer: true }, (socket) => {
+      this.handleStream(socket)
+    })
+
+    const signalServer = new SignalServer({ noServer: true })
+    const signalWss = signalServer.ws
+
+    server.on('upgrade', function upgrade(request, socket, head) {
+      const pathname = url.parse(request.url).pathname;
+
+      if (pathname === '/proxy') {
+        proxyWss.handleUpgrade(request, socket, head, (ws) => proxyWss.emit('connection', ws, request));
+      } else if (pathname === '/signal') {
+        signalWss.handleUpgrade(request, socket, head, (ws) => signalWss.emit('connection', ws, request));
+      } else {
+        console.warn('Invalid path. The path must be "/proxy" or "/signal"')
+        socket.destroy();
+      }
+    });
+  }
+}
+
+module.exports = HyperswarmServer

--- a/test.js
+++ b/test.js
@@ -1,12 +1,12 @@
 const hyperswarm = require('hyperswarm')
-const HyperswarmServer = require('hyperswarm-proxy-ws/server')
+const HyperswarmServer = require('./server')
 const hyperswarmweb = require('./')
 const test = require('tape')
 const getPort = require('get-port')
 const crypto = require('crypto')
 
 test('Connect to local hyperswarm through local proxy', async (t) => {
-  t.plan(6)
+  t.plan(7)
   try {
     // Initialize local hyperswarm instance, listen for peers
     const swarm = hyperswarm()
@@ -18,9 +18,9 @@ test('Connect to local hyperswarm through local proxy', async (t) => {
     server.listen(port)
 
     // Initialize client
-    const hostname = `ws://localhost:${port}/`
+    const hostname = `ws://localhost:${port}`
     const client = hyperswarmweb({
-      wsProxy: hostname
+      bootstrap: [hostname]
     })
 
     // Test connections in regular hyperswarm
@@ -72,6 +72,10 @@ test('Connect to local hyperswarm through local proxy', async (t) => {
 
     // Join channel on client
     client.join(key)
+
+    client.webrtc.signal.once('connected', () => {
+      t.pass('should establish a websocket connection with the signal')
+    })
   } catch (e) {
     console.error(e)
     t.fail(e)


### PR DESCRIPTION
Hey @RangerMauve, 

This PR does a couple of things:

- It updates discovery-swarm-webrtc to v4 (I did a mistake in v3 and I have to release a new one major version :smile:).

- Since v4 is using clean websockets I thought it could be nice to provide support for websocket signal connections into HyperswarmServer. So when the user runs a HyperswarmServer it provides the proxy and the signal together.
Of course is for discussion, because for example it duplicates the connections to the server.

btw I'm using a branch of hyperswarm-proxy-ws for now, related: https://github.com/RangerMauve/hyperswarm-proxy-ws/pull/4