### PR TITLE
Implement swarm.peers and emit disconnection event

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ swarm.on('connection', (socket, details) => {
 
 swarm.on('disconnection', (socket, details) => {
   console.log(details.peer.host, 'disconnected!')
+  console.log('now we have', swarm.peers.length, 'peers!')
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ swarm.on('connection', (socket, details) => {
   // you can now use the socket as a stream, eg:
   // socket.pipe(hypercore.replicate()).pipe(socket)
 })
+
+swarm.on('disconnection', (socket, details) => {
+  console.log(details.peer.host, 'disconnected!')
+})
 ```
 
 Build it with [Browserify](http://browserify.org/) to get it running on the web.

--- a/index.js
+++ b/index.js
@@ -74,6 +74,10 @@ class HyperswarmWeb extends EventEmitter {
     this.emit('connection', connection, info)
   }
 
+  _handleDisconnection (connection, info) {
+    this.emit('disconnection', connection, info)
+  }
+
   address () {
     // TODO: What could possibly go here?!?!?!
     return { port: 0, family: 'IPv4', address: '127.0.0.1' }
@@ -86,9 +90,11 @@ class HyperswarmWeb extends EventEmitter {
 
     this.webrtc = webRTCSwarm(this.webrtcOpts)
     this.webrtc.on('connection', (connection, info) => this._handleConnection(connection, webrtcPeerInfo(info)))
+    this.webrtc.on('connection-closed', (connection, info) => this._handleDisconnection(connection, webrtcPeerInfo(info)))
 
     this.ws = new HyperswarmClient(this.wsOpts)
     this.ws.on('connection', (connection, info) => this._handleConnection(connection, info))
+    this.ws.on('disconnection', (connection, info) => this._handleDisconnection(connection, info))
   }
 
   join (key, opts) {

--- a/index.js
+++ b/index.js
@@ -68,14 +68,21 @@ class HyperswarmWeb extends EventEmitter {
 
     this.isListening = false
     this.destroyed = false
+    this._peers = new Map()
   }
 
   _handleConnection (connection, info) {
+    this._peers.set(info.peer.host, { connection, info })
     this.emit('connection', connection, info)
   }
 
   _handleDisconnection (connection, info) {
+    this._peers.delete(info.peer.host)
     this.emit('disconnection', connection, info)
+  }
+
+  get peers () {
+    return Array.from(this._peers.values())
   }
 
   address () {


### PR DESCRIPTION
Yet another `Map()` of peers. I could dig more into the lower layers, but I thought it was easier to implement a `Map` in the swarm, since we catch the `connection` and `disconnection` events. I'd be happy with the `'disconnection'` event only since I could move the Map to my layer, but the hyperswarm api has `swarm.peers` so I thought I'd put it there so we implement more similar functionality.